### PR TITLE
Make StarlightBlog work with StarlightImageZoom

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -12,7 +12,7 @@ import starlightImageZoom from 'starlight-image-zoom';
 import starlightUtils from "@lorenzo_lewis/starlight-utils";
 import { visualizer } from "rollup-plugin-visualizer";
 
-//import starlightBlog from 'starlight-blog'
+import starlightBlog from 'starlight-blog'
 
 import react from "@astrojs/react";
 
@@ -37,7 +37,7 @@ export default defineConfig({
 		skipGeneration: process.env.GITHUB_ACTIONS === "true"
 	}), vtbot({}), starlight({
 		plugins: [starlightImageZoom(),
-		//starlightBlog(),
+		starlightBlog(), // TODO
 		starlightUtils({
 			multiSidebar: {
 				switcherStyle: 'horizontalList'
@@ -55,7 +55,8 @@ export default defineConfig({
 		components: {
 			Head: "./src/components/starlight/Head.astro",
 			PageTitle: "./src/components/starlight/PageTitle.astro",
-			Pagination: "./src/components/starlight/FeelBack.astro"
+			Pagination: "./src/components/starlight/FeelBack.astro",
+      MarkdownContent: "./src/components/MarkdownContent.astro"
 		},
 		title: "Bag of Tricks",
 		head: [{

--- a/src/components/MarkdownContent.astro
+++ b/src/components/MarkdownContent.astro
@@ -1,0 +1,8 @@
+---
+import type { Props } from '@astrojs/starlight/props'
+import Default from "starlight-blog/overrides/MarkdownContent.astro"
+import ImageZoom from 'starlight-image-zoom/components/ImageZoom.astro'
+---
+
+<ImageZoom />
+<Default {...Astro.props}><slot /></Default>


### PR DESCRIPTION
Hello!

If you every want to use Starlight Blog, it will probably not work 100% as you expect with Starlight Image Zoom.
This PR adds an override component, so that both Plugins can work together.

I hope this helps in the future!

Have a nice day, bye!